### PR TITLE
Add support for `.jsx` and `.tsx` files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,7 +35,9 @@ function activate(context) {
   const subscription = vscode.languages.registerHoverProvider(
     [
       { language: 'javascript', scheme: 'file' },
+      { language: 'javascriptreact', scheme: 'file' },
       { language: 'typescript', scheme: 'file' },
+      { language: 'typescriptreact', scheme: 'file' },
       { language: 'vue', scheme: 'file' },
       { language: 'svelte', scheme: 'file' },
       { language: 'python', scheme: 'file' },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   },
   "activationEvents": [
     "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "onLanguage:typescript",
+    "onLanguage:typescriptreact",
     "onLanguage:python",
     "onLanguage:svelte",
     "onLanguage:vue"

--- a/src/languages/index.js
+++ b/src/languages/index.js
@@ -3,8 +3,10 @@ const python = require('./python');
 
 module.exports = {
   javascript,
+  javascriptreact: javascript,
   svelte: javascript,
   typescript: javascript,
+  typescriptreact: javascript,
   vue: javascript,
   python,
 };


### PR DESCRIPTION
Hey @IoannP! 👋 Love your extension.

I noticed that it's not active in `.tsx` and `.jsx` files which are just JS/TS with React syntax allowed.

Hope you don't mind the addition.